### PR TITLE
Set payproc URLs to use https protocol all of the time.

### DIFF
--- a/src/app/js/media.js
+++ b/src/app/js/media.js
@@ -2,8 +2,8 @@ var day_avg = false;
 var delay = 5000;
 var keepHash;
 var mainFile;
-var URL_RECV = window.location.protocol+"//api.alexandria.io/payproc/receive";
-var URL_GETRECVD = window.location.protocol+"//api.alexandria.io/payproc/getreceivedbyaddress/";
+var URL_RECV = "https://api.alexandria.io/payproc/receive";
+var URL_GETRECVD = "https://api.alexandria.io/payproc/getreceivedbyaddress/";
 
 window.doMountMediaBrowser = function (el, data) {
     console.log (el, data);


### PR DESCRIPTION
The server, api.alexandria.io, now returns a 301 error (permanently moved resource) when accessing "http://api.alexandria.io/payproc/..." In Chrome and Safari, this causes a failure which prevents the paywall from displaying because a payment address never returns to the invoking http client (window.location.protocol == 'http'). In Firefox, when window.location.protocol == http, it recognizes the 301 error and navigates to the https://api.alexandria.io/payproc address as provided in the location header. Thus, in Firefox, the paywall displays regardless of how alexandria.io was originally accessed (via http or https).

This change forces the browser to always use the https protocol, which works with both Chrome and Firefox.