### PR TITLE
Bitcoin paywall creates QR Code locally.

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -1122,8 +1122,7 @@
 				                   </div>
 				                   <div class="pwyw-footer">
 				                       <span class="pwyw-btc-download-price">dl-price</span> BTC to<br>
-				                       <div class="pwyw-qrcode">
-				                           <img src="" />
+				                       <div id="pwyw-btc-download-qrcode" class="pwyw-qrcode">
 				                       </div>
 				                       <span class="pwyw-btc-address">                            </span>
 				                   </div>
@@ -1145,8 +1144,7 @@
 				                   </div>
 				                   <div class="pwyw-footer">
 				                       <span class="pwyw-btc-play-price">play-price</span> BTC to
-				                       <div class="pwyw-qrcode">
-				                           <img src="http://www.wired.com/images_blogs/magazine/2013/04/qrcode_f.jpg" />
+				                       <div id="pwyw-btc-play-qrcode" class="pwyw-qrcode">
 				                       </div>
 				                       <span class="pwyw-btc-address">1CvDLWNzX4PEkzMU7t2pVGsT858pMiNorQ
 				                       </span>

--- a/src/app/js/media.js
+++ b/src/app/js/media.js
@@ -773,8 +773,31 @@ function resetQR() {
 
 function setQR(address, amount) {
     if (amount) {
-        var url = "http://api.qrserver.com/v1/create-qr-code/?size=300x300&data=bitcoin:" + address + "?amount=" + amount;
-        $('.pwyw-qrcode img').attr("src", url);
+
         $('.pwyw-btc-address').text(address);
+        var qrOptions = {
+             text: "bitcoin:" + address + "?amount=" + amount,
+		     width: 300,
+		     height: 300,
+		     colorDark : "#000000",
+		     colorLight : "#FFFFFF",
+		     correctLevel : QRCode.CorrectLevel.H };
+
+        var qrPlay = document.getElementById('pwyw-btc-play-qrcode');
+        var qrcodePlay
+        if (qrPlay) {
+            qrcodePlay = new QRCode(qrPlay, qrOptions);
+        }
+
+        var qrDwnload = document.getElementById('pwyw-btc-download-qrcode');
+        var qrcodeDwnload;
+        if (qrDwnload) {
+            qrcodeDwnload = new QRCode(qrDwnload, qrOptions);
+        }
+        
+
+        $('.pwyw-qrcode img').each(function() {
+            $(this).css('margin','auto');
+        });
     }
 }

--- a/src/app/js/media.js
+++ b/src/app/js/media.js
@@ -772,8 +772,17 @@ function resetQR() {
 }
 
 function setQR(address, amount) {
-    if (amount) {
+    // Reset the QR Code Div
+    var qrCodes = ['pwyw-btc-play-qrcode', 'pwyw-btc-download-qrcode'];
 
+    for (qrCodeId of qrCodes) {
+        var parNode = document.getElementById(qrCodeId);
+        while (parNode.firstChild) {
+            parNode.removeChild(parNode.firstChild);
+        }
+    }
+
+    if (amount) {
         $('.pwyw-btc-address').text(address);
         var qrOptions = {
              text: "bitcoin:" + address + "?amount=" + amount,
@@ -783,18 +792,13 @@ function setQR(address, amount) {
 		     colorLight : "#FFFFFF",
 		     correctLevel : QRCode.CorrectLevel.H };
 
-        var qrPlay = document.getElementById('pwyw-btc-play-qrcode');
-        var qrcodePlay
-        if (qrPlay) {
-            qrcodePlay = new QRCode(qrPlay, qrOptions);
-        }
-
-        var qrDwnload = document.getElementById('pwyw-btc-download-qrcode');
-        var qrcodeDwnload;
-        if (qrDwnload) {
-            qrcodeDwnload = new QRCode(qrDwnload, qrOptions);
-        }
-        
+        for (qrCodeId of qrCodes) {
+            var qrPlay = document.getElementById(qrCodeId);
+            var qrcodePlay
+            if (qrPlay) {
+                qrcodePlay = new QRCode(qrPlay, qrOptions);
+            }
+        }        
 
         $('.pwyw-qrcode img').each(function() {
             $(this).css('margin','auto');


### PR DESCRIPTION
The paywall for both btc-for-play and btc-for-download generates its QR Code using jQuery QRCode.

After I committed the changes, I realized I could eliminate the use of the element id's. But, this solution works and I can refactor it later.