### PR TITLE
Use minBuy or minPlay for payment price.

### DIFF
--- a/src/app/js/media.js
+++ b/src/app/js/media.js
@@ -366,11 +366,11 @@ function showPaymentOption(e) {
         if ($(self).closest('td').hasClass('tb-price-download') || $(self).closest('li').hasClass('pwyw-action-download') || $(self).closest('tbody').hasClass('playlist-extra-files')){
             actionElement = $('.pwyw-activate-download');
             action = 'download';
-            price = fileData.sugBuy;
+            price = fileData.minBuy ? fileData.minBuy : 0;
         } else {
             actionElement = $('.pwyw-activate-play');
             action = 'play';
-            price = fileData.sugPlay;
+            price = fileData.minPlay ? fileData.minPlay : 0;
 		}
         if (price === 0 || price === undefined || price == NaN){
             onPaymentDone(action, fileData);


### PR DESCRIPTION
This change uses the minBuy or minPlay for the payment amount sent to payproc from the paywall. Unfortunately, the default amount shown in the paywall QR code display is set to the minimum purchase. I'll have to make the necessary changes to the UI next time.